### PR TITLE
Fixing bug and updating cpe

### DIFF
--- a/templates/athenak/perlmutter-cpu/batch.sub
+++ b/templates/athenak/perlmutter-cpu/batch.sub
@@ -20,7 +20,7 @@ set -e                          # Abort on errors
 cd @RUNDIR@
 
 module purge
-module load cpe/23.12
+module load cpe/24.07
 module load PrgEnv-gnu
 module load craype-x86-milan
 module load xpmem
@@ -49,7 +49,7 @@ fi
 export MPICH_MPIIO_HINTS="*:abort_on_rw_error=enable:romio_cb_write=disable"
 export OMP_PROC_BIND=spread
 export OMP_PLACES=threads
-export OMP_NUM_THREADS=$(@CPUS_PER_TASK@ / 2)
+export OMP_NUM_THREADS=$((@CPUS_PER_TASK@ / 2))
 srun \
     -n $((@NODES@ * @TASKS_PER_NODE@)) \
     @EXECUTABLE@ \

--- a/templates/athenak/perlmutter-cpu/batch.sub
+++ b/templates/athenak/perlmutter-cpu/batch.sub
@@ -21,6 +21,7 @@ cd @RUNDIR@
 
 module purge
 module load cpe/24.07
+source /opt/cray/pe/cpe/24.07/restore_lmod_system_defaults.sh
 module load PrgEnv-gnu
 module load craype-x86-milan
 module load xpmem

--- a/templates/athenak/perlmutter-cpu/environment.sh
+++ b/templates/athenak/perlmutter-cpu/environment.sh
@@ -1,5 +1,5 @@
 module purge
-module load cpe/23.12
+module load cpe/24.07
 module load PrgEnv-gnu
 module load craype-x86-milan
 module load xpmem

--- a/templates/athenak/perlmutter-cpu/environment.sh
+++ b/templates/athenak/perlmutter-cpu/environment.sh
@@ -1,5 +1,6 @@
 module purge
 module load cpe/24.07
+source /opt/cray/pe/cpe/24.07/restore_lmod_system_defaults.sh
 module load PrgEnv-gnu
 module load craype-x86-milan
 module load xpmem


### PR DESCRIPTION
In the template for `templates/athenak/perlmutter-cpu` there is a tiny bug in the batch script that prevents fixing the number of OpenMP threads (`OMP_NUM_THREADS` variable) to the desired number. In addition, the library `cpe/23.12` is deprecated now in perlmutter and needed to be updated to the `cpe/24.07` version. 